### PR TITLE
Add environment variables to Integration CRD

### DIFF
--- a/deploy/crds/hello_world_integration.yaml
+++ b/deploy/crds/hello_world_integration.yaml
@@ -20,5 +20,8 @@ metadata:
   name: hello-world
 spec:
   replicas: 1
-  image: indikasampath2000/wso2-mi-hello-world
+  image: sanojp/mi:v8
   port: 8290
+  env:
+    - name: DEMO_GREETING
+      value: "Hello_from_the_mi"

--- a/pkg/apis/integration/v1alpha1/integration_types.go
+++ b/pkg/apis/integration/v1alpha1/integration_types.go
@@ -19,6 +19,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,6 +35,8 @@ type IntegrationSpec struct {
 	Image string `json:"image"`
 	// HTTP traffic serving port of the micro integrator runtime
 	Port int32 `json:"port"`
+	// List of environment variables to set for the integration.
+	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 
 // IntegrationStatus defines the observed state of Integration

--- a/pkg/controller/integration/integration_controller.go
+++ b/pkg/controller/integration/integration_controller.go
@@ -238,6 +238,7 @@ func (r *ReconcileIntegration) deploymentForIntegration(m *integrationv1alpha1.I
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8290,
 						}},
+						Env: m.Spec.Env,
 					}},
 				},
 			},


### PR DESCRIPTION
## Purpose
With this, the Integration CRD will be able to set the environment variables defined in the deployment yaml.
